### PR TITLE
RELEASE_NAME_PREFIXが指定されている場合にprefixがないlatest_release_tagがうまく取得できない問題を修正した

### DIFF
--- a/lib/ruboty/github/actions/create_release.rb
+++ b/lib/ruboty/github/actions/create_release.rb
@@ -55,13 +55,22 @@ module Ruboty
 
         def latest_version
           Gem::Version.new(
-            latest_release_tag_name.slice(
-              Range.new(
-                release_name_prefix_length,
-                -1,
-              )
+            latest_release_version_number,
+          )
+        end
+
+        def latest_release_version_number
+          range_start = latest_release_tag_name_matched_to_prefix? ? release_name_prefix_length : 0
+          latest_release_tag_name.slice(
+            Range.new(
+              range_start,
+              -1,
             )
           )
+        end
+
+        def latest_release_tag_name_matched_to_prefix?
+          release_name_regexp.match?(latest_release_tag_name)
         end
 
         def latest_release_tag_name


### PR DESCRIPTION
https://github.com/Pegasus204/openapi_merger/issues/28 の問題を修正した。
`RELEASE_NAME_PREFIX`に指定されている場合に`latest_release_tag`の先頭から`RELEASE_NAME_PREFIX`の文字列長分を削ることでrelease_tagのバージョン番号だけを抜き出していたが、`RELEASE_NAME_PREFIX`が設定されている場合に`1.2.3`などのprefixがない`latest_release_tag`を受け取るとバージョン番号がうまく抜き出せないバグがあった。
そのため`latest_release_tag`に`RELEASE_NAME_PREFIX`に指定されている文字列が含まれている場合だけ先頭から文字列を削る処理を実行し、それ以外は`latest_release_tag`の先頭からバージョン番号として扱うようにした。
(ただし`latest_release_tag`に`RELEASE_NAME_PREFIX`以外の文字列が指定されていた場合にコケるので要修正)